### PR TITLE
gf: allow method shadowing with exact signatures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,16 @@ New language features
 Language changes
 ----------------
 
+ - When methods are replaced with exactly equivalent ones, the old method is no
+   longer deleted implicitly simultaneously, although the new method does take
+   priority and become morespecific than the old method. Thus if the new method
+   is deleted later, the old method will resume operating. This can be useful
+   to mocking frameworks (such as has been seen in SparseArrays, Pluto,
+   Mocking, among others), as they do not need to explicitly restore the old
+   method. While inference and compilation still must be repeated with this, it
+   also may pave the way for inference to be able to intelligently re-use the
+   old results, once the new method is deleted. ([#TBD])
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -887,6 +887,7 @@ A special case where exact behavior is guaranteed: when `T <: S`,
 typeintersect(@nospecialize(a), @nospecialize(b)) = (@_total_meta; ccall(:jl_type_intersection, Any, (Any, Any), a::Type, b::Type))
 
 morespecific(@nospecialize(a), @nospecialize(b)) = (@_total_meta; ccall(:jl_type_morespecific, Cint, (Any, Any), a::Type, b::Type) != 0)
+morespecific(a::Method, b::Method) = ccall(:jl_method_morespecific, Cint, (Any, Any), a, b) != 0
 
 """
     fieldoffset(type, i)
@@ -2488,7 +2489,7 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
             for match in ms
                 m = match.method
                 match.fully_covers || continue
-                if minmax === nothing || morespecific(m.sig, minmax.sig)
+                if minmax === nothing || morespecific(m, minmax)
                     minmax = m
                 end
             end
@@ -2498,8 +2499,8 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
             for match in ms
                 m = match.method
                 m === minmax && continue
-                if !morespecific(minmax.sig, m.sig)
-                    if match.fully_covers || !morespecific(m.sig, minmax.sig)
+                if !morespecific(minmax, m)
+                    if match.fully_covers || !morespecific(m, minmax)
                         return true
                     end
                 end

--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -521,10 +521,6 @@ than the other.)  Likewise, `Tuple{Int,Vararg{Int}}` is not a subtype of `Tuple{
 considered more specific. However, `morespecific` does get a bonus for length: in particular,
 `Tuple{Int,Int}` is more specific than `Tuple{Int,Vararg{Int}}`.
 
-If you're debugging how methods get sorted, it can be convenient to define the function:
-
-```julia
-type_morespecific(a, b) = ccall(:jl_type_morespecific, Cint, (Any,Any), a, b)
-```
-
-which allows you to test whether tuple type `a` is more specific than tuple type `b`.
+Additionally, if 2 methods are defined with identical signatures, per type-equal, then they
+will instead by compared by order of addition, such that the later method is morespecific
+than the earlier one.

--- a/src/gf.c
+++ b/src/gf.c
@@ -276,7 +276,7 @@ JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt, jl_value_t *typ
     // TODO: this is sort of an odd lookup strategy (and the only user of
     // jl_typemap_assoc_by_type with subtype=0), while normally jl_gf_invoke_lookup would be
     // expected to be used instead
-    struct jl_typemap_assoc search = {type, world, NULL, 0, ~(size_t)0};
+    struct jl_typemap_assoc search = {type, world, NULL};
     jl_typemap_entry_t *sf = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(&mt->defs), &search, jl_cachearg_offset(mt), /*subtype*/0);
     if (!sf)
         return jl_nothing;
@@ -299,6 +299,8 @@ jl_datatype_t *jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_a
     m->module = jl_core_module;
     m->isva = 1;
     m->nargs = 2;
+    m->primary_world = 1;
+    m->deleted_world = ~(size_t)0;
     m->sig = (jl_value_t*)jl_anytuple_type;
     m->slot_syms = jl_an_empty_string;
     m->nospecialize = 0;
@@ -309,7 +311,7 @@ jl_datatype_t *jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_a
     JL_GC_PUSH2(&m, &newentry);
 
     newentry = jl_typemap_alloc(jl_anytuple_type, NULL, jl_emptysvec,
-            (jl_value_t*)m, 1, ~(size_t)0);
+            (jl_value_t*)m, m->primary_world, m->deleted_world);
     jl_typemap_insert(&mt->defs, (jl_value_t*)mt, newentry, jl_cachearg_offset(mt));
 
     jl_method_instance_t *mi = jl_get_specialized(m, (jl_value_t*)jl_anytuple_type, jl_emptysvec);
@@ -1236,7 +1238,7 @@ static jl_method_instance_t *cache_method(
             if (entry)
                 return entry->func.linfo;
         }
-        struct jl_typemap_assoc search = {(jl_value_t*)tt, world, NULL, 0, ~(size_t)0};
+        struct jl_typemap_assoc search = {(jl_value_t*)tt, world, NULL};
         jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(cache), &search, offs, /*subtype*/1);
         if (entry && entry->func.value)
             return entry->func.linfo;
@@ -1387,7 +1389,7 @@ static jl_method_instance_t *cache_method(
     // short-circuit if an existing entry is already present
     // that satisfies our requirements
     if (cachett != tt) {
-        struct jl_typemap_assoc search = {(jl_value_t*)cachett, world, NULL, 0, ~(size_t)0};
+        struct jl_typemap_assoc search = {(jl_value_t*)cachett, world, NULL};
         jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(cache), &search, offs, /*subtype*/1);
         if (entry && jl_egal((jl_value_t*)entry->simplesig, simplett ? (jl_value_t*)simplett : jl_nothing) &&
                 jl_egal((jl_value_t*)guardsigs, (jl_value_t*)entry->guardsigs)) {
@@ -1451,7 +1453,7 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt JL_PROPAGATE
     }
 
     if (!mi) {
-        struct jl_typemap_assoc search = {(jl_value_t*)tt, world, NULL, 0, ~(size_t)0};
+        struct jl_typemap_assoc search = {(jl_value_t*)tt, world, NULL};
         jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(jl_atomic_load_relaxed(&mt->cache), &search, jl_cachearg_offset(mt), /*subtype*/1);
         if (entry)
             mi = entry->func.linfo;
@@ -1491,7 +1493,8 @@ static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_in
     jl_method_t *oldmethod = oldentry->func.method;
     if (closure->match.issubty // e.g. jl_subtype(closure->newentry.sig, oldentry->sig)
         && jl_subtype(oldmethod->sig, (jl_value_t*)closure->newentry->sig)) { // e.g. jl_type_equal(closure->newentry->sig, oldentry->sig)
-        closure->replaced = oldentry;
+        if (closure->replaced == NULL || closure->replaced->min_world < oldentry->min_world)
+            closure->replaced = oldentry; // must pick the newest insertion (both are still valid)
     }
     if (closure->shadowed == NULL)
         closure->shadowed = (jl_value_t*)jl_alloc_vec_any(0);
@@ -1795,13 +1798,18 @@ static int invalidate_mt_cache(jl_typemap_entry_t *oldentry, void *closure0)
     }
     return 1;
 }
+
+struct disable_mt_env {
+    jl_method_t *replaced;
+    size_t max_world;
+};
 static int disable_mt_cache(jl_typemap_entry_t *oldentry, void *closure0)
 {
-    struct invalidate_mt_env *env = (struct invalidate_mt_env*)closure0;
+    struct disable_mt_env *env = (struct disable_mt_env*)closure0;
     if (jl_atomic_load_relaxed(&oldentry->max_world) < ~(size_t)0)
         return 1;
     jl_method_t *m = oldentry->func.linfo->def.method;
-    if (m == env->newentry->func.method)
+    if (m == env->replaced)
         jl_atomic_store_relaxed(&oldentry->max_world, env->max_world);
     return 1;
 }
@@ -1815,33 +1823,23 @@ static int typemap_search(jl_typemap_entry_t *entry, void *closure)
     return 1;
 }
 
-static jl_typemap_entry_t *do_typemap_search(jl_methtable_t *mt JL_PROPAGATES_ROOT, jl_method_t *method) JL_NOTSAFEPOINT;
-
-#ifndef __clang_gcanalyzer__ /* in general, jl_typemap_visitor could be a safepoint, but not for typemap_search */
-static jl_typemap_entry_t *do_typemap_search(jl_methtable_t *mt JL_PROPAGATES_ROOT, jl_method_t *method) JL_NOTSAFEPOINT {
+static jl_typemap_entry_t *do_typemap_search(jl_methtable_t *mt JL_PROPAGATES_ROOT, jl_method_t *method) {
     jl_value_t *closure = (jl_value_t*)(method);
     if (jl_typemap_visitor(jl_atomic_load_relaxed(&mt->defs), typemap_search, &closure))
         jl_error("method not in method table");
     return (jl_typemap_entry_t *)closure;
 }
-#endif
 
-static void jl_method_table_invalidate(jl_methtable_t *mt, jl_typemap_entry_t *methodentry, size_t max_world)
+static void jl_method_table_invalidate(jl_methtable_t *mt, jl_method_t *replaced, size_t max_world)
 {
     if (jl_options.incremental && jl_generating_output())
         jl_error("Method deletion is not possible during Module precompile.");
-    jl_method_t *method = methodentry->func.method;
-    assert(!method->is_for_opaque_closure);
+    assert(!replaced->is_for_opaque_closure);
     assert(jl_atomic_load_relaxed(&jl_world_counter) == max_world);
-    assert(jl_atomic_load_relaxed(&method->deleted_world) == ~(size_t)0);
-    jl_atomic_store_relaxed(&method->deleted_world, max_world);
-    jl_atomic_store_relaxed(&methodentry->max_world, max_world);
     // drop this method from mt->cache
-    struct invalidate_mt_env mt_cache_env;
+    struct disable_mt_env mt_cache_env;
     mt_cache_env.max_world = max_world;
-    mt_cache_env.newentry = methodentry;
-    mt_cache_env.shadowed = NULL;
-    mt_cache_env.invalidated = 0;
+    mt_cache_env.replaced = replaced;
     jl_typemap_visitor(jl_atomic_load_relaxed(&mt->cache), disable_mt_cache, (void*)&mt_cache_env);
     jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mt->leafcache);
     size_t i, l = leafcache->length;
@@ -1849,15 +1847,14 @@ static void jl_method_table_invalidate(jl_methtable_t *mt, jl_typemap_entry_t *m
         jl_typemap_entry_t *oldentry = (jl_typemap_entry_t*)jl_genericmemory_ptr_ref(leafcache, i);
         if (oldentry) {
             while ((jl_value_t*)oldentry != jl_nothing) {
-                if (jl_atomic_load_relaxed(&oldentry->max_world) == ~(size_t)0)
-                    jl_atomic_store_relaxed(&oldentry->max_world, mt_cache_env.max_world);
+                disable_mt_cache(oldentry, (void*)&mt_cache_env);
                 oldentry = jl_atomic_load_relaxed(&oldentry->next);
             }
         }
     }
     // Invalidate the backedges
     int invalidated = 0;
-    jl_value_t *specializations = jl_atomic_load_relaxed(&method->specializations);
+    jl_value_t *specializations = jl_atomic_load_relaxed(&replaced->specializations);
     JL_GC_PUSH1(&specializations);
     if (!jl_is_svec(specializations))
         specializations = (jl_value_t*)jl_svec1(specializations);
@@ -1873,7 +1870,7 @@ static void jl_method_table_invalidate(jl_methtable_t *mt, jl_typemap_entry_t *m
     // XXX: this might have resolved an ambiguity, for which we have not tracked the edge here,
     // and thus now introduce a mistake into inference
     if (invalidated && _jl_debug_method_invalidation) {
-        jl_array_ptr_1d_push(_jl_debug_method_invalidation, (jl_value_t*)method);
+        jl_array_ptr_1d_push(_jl_debug_method_invalidation, (jl_value_t*)replaced);
         jl_value_t *loctag = jl_cstr_to_string("jl_method_table_disable");
         JL_GC_PUSH1(&loctag);
         jl_array_ptr_1d_push(_jl_debug_method_invalidation, loctag);
@@ -1888,7 +1885,11 @@ JL_DLLEXPORT void jl_method_table_disable(jl_methtable_t *mt, jl_method_t *metho
     JL_LOCK(&mt->writelock);
     // Narrow the world age on the method to make it uncallable
     size_t world = jl_atomic_load_relaxed(&jl_world_counter);
-    jl_method_table_invalidate(mt, methodentry, world);
+    assert(method == methodentry->func.method);
+    assert(jl_atomic_load_relaxed(&method->deleted_world) == ~(size_t)0);
+    jl_atomic_store_relaxed(&method->deleted_world, world);
+    jl_atomic_store_relaxed(&methodentry->max_world, world);
+    jl_method_table_invalidate(mt, method, world);
     jl_atomic_store_release(&jl_world_counter, world + 1);
     JL_UNLOCK(&mt->writelock);
     JL_UNLOCK(&world_counter_lock);
@@ -2006,7 +2007,8 @@ void jl_method_table_activate(jl_methtable_t *mt, jl_typemap_entry_t *newentry)
         oldvalue = (jl_value_t*)replaced;
         invalidated = 1;
         method_overwrite(newentry, replaced->func.method);
-        jl_method_table_invalidate(mt, replaced, max_world);
+        // this is an optimized version of below, given we know the type-intersection is exact
+        jl_method_table_invalidate(mt, replaced->func.method, max_world);
     }
     else {
         jl_method_t *const *d;
@@ -2817,7 +2819,7 @@ static jl_method_instance_t *jl_get_compile_hint_specialization(jl_tupletype_t *
             exclude = 0;
             for (size_t j = n-1; j > i; j--) {  // more general methods maybe more likely to be at end
                 jl_method_match_t *match2 = (jl_method_match_t*)jl_array_ptr_ref(matches, j);
-                if (jl_type_morespecific(match1->method->sig, match2->method->sig)) {
+                if (jl_method_morespecific(match1->method, match2->method)) {
                     exclude = 1;
                     break;
                 }
@@ -3348,18 +3350,23 @@ static int ml_matches_visitor(jl_typemap_entry_t *ml, struct typemap_intersectio
             closure->match.min_valid = max_world + 1;
         return 1;
     }
-    else {
-        // intersect the env valid range with method's inclusive valid range
-        if (closure->match.min_valid < min_world)
-            closure->match.min_valid = min_world;
-        if (closure->match.max_valid > max_world)
-            closure->match.max_valid = max_world;
-    }
     jl_method_t *meth = ml->func.method;
     if (closure->lim >= 0 && jl_is_dispatch_tupletype(meth->sig)) {
-        if (closure->lim == 0)
-            return 0;
-        closure->lim--;
+        int replaced = 0;
+        // check if this is replaced, in which case we need to avoid double-counting it against the limit
+        // (although it will figure out later which one to keep and return)
+        size_t len = jl_array_nrows(closure->t);
+        for (int i = 0; i < len; i++) {
+            if (jl_types_equal(((jl_method_match_t*)jl_array_ptr_ref(closure->t, i))->method->sig, meth->sig)) {
+                replaced = 1;
+                break;
+            }
+        }
+        if (!replaced) {
+            if (closure->lim == 0)
+                return 0;
+            closure->lim--;
+        }
     }
     // don't need to consider other similar methods if this ml will always fully intersect with them and dominates all of them
     if (!closure->include_ambiguous || closure->lim != -1)
@@ -3383,7 +3390,6 @@ static int ml_mtable_visitor(jl_methtable_t *mt, void *closure0)
     struct typemap_intersection_env* env = (struct typemap_intersection_env*)closure0;
     return jl_typemap_intersection_visitor(jl_atomic_load_relaxed(&mt->defs), jl_cachearg_offset(mt), env);
 }
-
 
 // Visit the candidate methods, starting from t[idx], to determine a possible valid sort ordering,
 // where every morespecific method appears before any method which it has a common
@@ -3435,7 +3441,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
             jl_method_t *m2 = matc2->method;
             if (jl_subtype(ti, m2->sig)) {
                 if (include_ambiguous) {
-                    if (!jl_type_morespecific((jl_value_t*)m2->sig, (jl_value_t*)m->sig))
+                    if (!jl_method_morespecific(m2, m))
                         continue;
                 }
                 visited->items[idx] = (void*)1;
@@ -3469,8 +3475,8 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
         // since we only care about sorting of the intersections the user asked us about
         if (!subt2 && jl_has_empty_intersection(m2->sig, m->sig))
             continue;
-        int msp = jl_type_morespecific((jl_value_t*)m->sig, (jl_value_t*)m2->sig);
-        int msp2 = !msp && jl_type_morespecific((jl_value_t*)m2->sig, (jl_value_t*)m->sig);
+        int msp = jl_method_morespecific(m, m2);
+        int msp2 = !msp && jl_method_morespecific(m2, m);
         if (!msp) {
             if (subt || !include_ambiguous || (lim != -1 && msp2)) {
                 if (subt2 || jl_subtype((jl_value_t*)ti, m2->sig)) {
@@ -3510,7 +3516,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                     jl_method_t *m2 = matc2->method;
                     if (jl_subtype(ti, m2->sig)) {
                         if (include_ambiguous) {
-                            if (!jl_type_morespecific((jl_value_t*)m2->sig, (jl_value_t*)m->sig))
+                            if (!jl_method_morespecific(m2, m))
                                 continue;
                         }
                         visited->items[idx] = (void*)1;
@@ -3586,7 +3592,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                     jl_method_t *m2 = matc2->method;
                     if (jl_subtype(ti, m2->sig)) {
                         if (include_ambiguous) {
-                            if (!jl_type_morespecific((jl_value_t*)m2->sig, (jl_value_t*)m->sig))
+                            if (!jl_method_morespecific(m2, m))
                                 continue;
                         }
                         visited->items[childidx] = (void*)1;
@@ -3617,8 +3623,7 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                         // we don't consider that a third method might be
                         // disrupting that ordering and just consider them
                         // pairwise to keep this simple).
-                        if (!jl_type_morespecific((jl_value_t*)m->sig, (jl_value_t*)m2->sig) &&
-                            !jl_type_morespecific((jl_value_t*)m2->sig, (jl_value_t*)m->sig)) {
+                        if (!jl_method_morespecific(m, m2) && !jl_method_morespecific(m2, m)) {
                             visited->items[childidx] = (void*)-1;
                             break;
                         }
@@ -3656,7 +3661,6 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
 }
 
 
-
 // This is the collect form of calling jl_typemap_intersection_visitor
 // with optimizations to skip fully shadowed methods.
 //
@@ -3692,7 +3696,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
             /* .ti = */ NULL, /* .env = */ jl_emptysvec, /* .issubty = */ 0},
         intersections, world, lim, include_ambiguous, /* .t = */ jl_an_empty_vec_any,
         /* .matc = */ NULL};
-    struct jl_typemap_assoc search = {(jl_value_t*)type, world, jl_emptysvec, 1, ~(size_t)0};
+    struct jl_typemap_assoc search = {(jl_value_t*)type, world, jl_emptysvec};
     jl_value_t *isect2 = NULL;
     JL_GC_PUSH6(&env.t, &env.matc, &env.match.env, &search.env, &env.match.ti, &isect2);
 
@@ -3760,6 +3764,9 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
         }
         if (!ml_mtable_visitor(mt, &env.match)) {
             JL_GC_POP();
+            // if we return early, set only the min/max valid collected from matching
+            *min_valid = env.match.min_valid;
+            *max_valid = env.match.max_valid;
             return jl_nothing;
         }
     }
@@ -3767,9 +3774,13 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
         // else: scan everything
         if (!jl_foreach_reachable_mtable(ml_mtable_visitor, &env.match)) {
             JL_GC_POP();
+            // if we return early, set only the min/max valid collected from matching
+            *min_valid = env.match.min_valid;
+            *max_valid = env.match.max_valid;
             return jl_nothing;
         }
     }
+    // if we return early, set only the min/max valid collected from matching
     *min_valid = env.match.min_valid;
     *max_valid = env.match.max_valid;
     // done with many of these values now
@@ -3789,7 +3800,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
                 jl_method_t *m = matc->method;
                 if (minmax != NULL) {
                     jl_method_t *minmaxm = minmax->method;
-                    if (jl_type_morespecific((jl_value_t*)minmaxm->sig, (jl_value_t*)m->sig))
+                    if (jl_method_morespecific(minmaxm, m))
                         continue;
                 }
                 minmax = matc;
@@ -3807,7 +3818,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
                 if (matc->fully_covers == FULLY_COVERS) {
                     jl_method_t *m = matc->method;
                     jl_method_t *minmaxm = minmax->method;
-                    if (!jl_type_morespecific((jl_value_t*)minmaxm->sig, (jl_value_t*)m->sig)) {
+                    if (!jl_method_morespecific(minmaxm, m)) {
                         minmax_ambig = 1;
                         minmax = NULL;
                         has_ambiguity = 1;
@@ -3832,7 +3843,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
                 jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, i);
                 if (matc->fully_covers != FULLY_COVERS) {
                     jl_method_t *m = matc->method;
-                    if (jl_type_morespecific((jl_value_t*)minmaxm->sig, (jl_value_t*)m->sig))
+                    if (jl_method_morespecific(minmaxm, m))
                         matc->fully_covers = SENTINEL; // put a sentinel value here for sorting
                     else
                         all_subtypes = 0;
@@ -3951,8 +3962,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
                         if (ti == jl_bottom_type)
                             continue;
                         // and they aren't themselves simply ordered
-                        if (jl_type_morespecific((jl_value_t*)m->sig, (jl_value_t*)m2->sig) ||
-                            jl_type_morespecific((jl_value_t*)m2->sig, (jl_value_t*)m->sig))
+                        if (jl_method_morespecific(m, m2) || jl_method_morespecific(m2, m))
                             continue;
                         // now look for a third method m3 that dominated these and that fully covered this intersection already
                         size_t k;
@@ -3965,8 +3975,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
                             jl_method_match_t *matc3 = (jl_method_match_t*)jl_array_ptr_ref(env.t, idx3);
                             jl_method_t *m3 = matc3->method;
                             if ((jl_subtype(ti, m3->sig) || (isect2 && jl_subtype(isect2, m3->sig)))
-                                    && jl_type_morespecific((jl_value_t*)m3->sig, (jl_value_t*)m->sig)
-                                    && jl_type_morespecific((jl_value_t*)m3->sig, (jl_value_t*)m2->sig)) {
+                                    && jl_method_morespecific(m3, m) && jl_method_morespecific(m3, m2)) {
                                 //if (jl_subtype(matc->spec_types, ti) || jl_subtype(matc->spec_types, matc3->m3->sig))
                                 //    // check if it covered not only this intersection, but all intersections with matc
                                 //    // if so, we do not need to check all of them separately
@@ -4008,6 +4017,18 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
             jl_array_del_end((jl_array_t*)env.t, len - j);
         len = j;
     }
+    for (j = 0; j < len; j++) {
+        jl_method_match_t *matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, j);
+        jl_method_t *m = matc->method;
+        // method applicability is the same as typemapentry applicability
+        size_t min_world = jl_atomic_load_relaxed(&m->primary_world);
+        size_t max_world = jl_atomic_load_relaxed(&m->deleted_world);
+        // intersect the env valid range with method lookup's inclusive valid range
+        if (env.match.min_valid < min_world)
+            env.match.min_valid = min_world;
+        if (env.match.max_valid > max_world)
+            env.match.max_valid = max_world;
+    }
     if (mt && cache_result && ((jl_datatype_t*)unw)->isdispatchtuple) { // cache_result parameter keeps this from being recursive
         if (len == 1 && !has_ambiguity) {
             env.matc = (jl_method_match_t*)jl_array_ptr_ref(env.t, 0);
@@ -4018,6 +4039,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
             JL_UNLOCK(&mt->writelock);
         }
     }
+    *min_valid = env.match.min_valid;
+    *max_valid = env.match.max_valid;
     if (ambig != NULL)
         *ambig = has_ambiguity;
     JL_GC_POP();

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -479,7 +479,7 @@
     XX(jl_type_intersection) \
     XX(jl_type_intersection_with_env) \
     XX(jl_type_morespecific) \
-    XX(jl_type_morespecific_no_subtype) \
+    XX(jl_method_morespecific) \
     XX(jl_type_union) \
     XX(jl_type_unionall) \
     XX(jl_unbox_bool) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -1710,6 +1710,7 @@ JL_DLLEXPORT jl_value_t *jl_type_unionall(jl_tvar_t *v, jl_value_t *body);
 JL_DLLEXPORT const char *jl_typename_str(jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_typeof_str(jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_type_morespecific(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT int jl_method_morespecific(jl_method_t *ma, jl_method_t *mb);
 
 STATIC_INLINE int jl_is_dispatch_tupletype(jl_value_t *v) JL_NOTSAFEPOINT
 {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1483,8 +1483,6 @@ struct jl_typemap_assoc {
     size_t const world;
     // outputs
     jl_svec_t *env; // subtype env (initialize to null to perform intersection without an environment)
-    size_t min_valid;
-    size_t max_valid;
 };
 
 jl_typemap_entry_t *jl_typemap_assoc_by_type(

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -5127,6 +5127,24 @@ JL_DLLEXPORT int jl_type_morespecific_no_subtype(jl_value_t *a, jl_value_t *b)
     return type_morespecific_(a, b, a, b, 0, NULL);
 }
 
+JL_DLLEXPORT int jl_method_morespecific(jl_method_t *ma, jl_method_t *mb)
+{
+    jl_value_t *a = (jl_value_t*)ma->sig;
+    jl_value_t *b = (jl_value_t*)mb->sig;
+    if (obviously_disjoint(a, b, 1))
+        return 0;
+    if (jl_has_free_typevars(a) || jl_has_free_typevars(b))
+        return 0;
+    if (jl_subtype(b, a)) {
+        if (jl_types_equal(a, b))
+            return ma->primary_world > mb->primary_world;
+        return 0;
+    }
+    if (jl_subtype(a, b))
+        return 1;
+    return type_morespecific_(a, b, a, b, 0, NULL);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1111,7 +1111,7 @@ function deserialize(s::AbstractSerializer, ::Type{Method})
         end
         if !is_for_opaque_closure
             mt = ccall(:jl_method_table_for, Any, (Any,), sig)
-            if mt !== nothing && nothing === ccall(:jl_methtable_lookup, Any, (Any, Any, UInt), mt, sig, typemax(UInt))
+            if mt !== nothing && nothing === ccall(:jl_methtable_lookup, Any, (Any, Any, UInt), mt, sig, Base.get_world_counter())
                 ccall(:jl_method_table_insert, Cvoid, (Any, Any, Ptr{Cvoid}), mt, meth, C_NULL)
             end
         end

--- a/test/compiler/invalidation.jl
+++ b/test/compiler/invalidation.jl
@@ -142,7 +142,9 @@ begin take!(GLOBAL_BUFFER)
     # this redefinition below should invalidate the cache of `pr48932_callee` but not that of `pr48932_caller`
     pr48932_callee(x) = (print(GLOBAL_BUFFER, x); nothing)
 
-    @test isempty(Base.specializations(Base.only(Base.methods(pr48932_callee))))
+    @test length(Base.methods(pr48932_callee)) == 2
+    @test Base.only(Base.methods(pr48932_callee, Tuple{Any})) === first(Base.methods(pr48932_callee))
+    @test isempty(Base.specializations(Base.only(Base.methods(pr48932_callee, Tuple{Any}))))
     let mi = only(Base.specializations(Base.only(Base.methods(pr48932_caller))))
         # Base.method_instance(pr48932_callee, (Any,))
         ci = mi.cache
@@ -206,7 +208,7 @@ begin take!(GLOBAL_BUFFER)
     # this redefinition below should invalidate the cache of `pr48932_callee_inferable` but not that of `pr48932_caller_unuse`
     pr48932_callee_inferable(x) = (print(GLOBAL_BUFFER, "foo"); x)
 
-    @test isempty(Base.specializations(Base.only(Base.methods(pr48932_callee_inferable))))
+    @test isempty(Base.specializations(Base.only(Base.methods(pr48932_callee_inferable, Tuple{Any}))))
     let mi = Base.method_instance(pr48932_caller_unuse, (Int,))
         ci = mi.cache
         @test isdefined(ci, :next)
@@ -266,7 +268,7 @@ begin take!(GLOBAL_BUFFER)
     # this redefinition below should invalidate the cache of `pr48932_callee_inlined` but not that of `pr48932_caller_inlined`
     @noinline pr48932_callee_inlined(@nospecialize x) = (print(GLOBAL_BUFFER, x); nothing)
 
-    @test isempty(Base.specializations(Base.only(Base.methods(pr48932_callee_inlined))))
+    @test isempty(Base.specializations(Base.only(Base.methods(pr48932_callee_inlined, Tuple{Any}))))
     let mi = Base.method_instance(pr48932_caller_inlined, (Int,))
         ci = mi.cache
         @test isdefined(ci, :next)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -474,7 +474,7 @@ fLargeTable() = 4
 fLargeTable(::Union, ::Union) = "a"
 @test fLargeTable(Union{Int, Missing}, Union{Int, Missing}) == "a"
 fLargeTable(::Union, ::Union) = "b"
-@test length(methods(fLargeTable)) == 205
+@test length(methods(fLargeTable)) == 206
 @test fLargeTable(Union{Int, Missing}, Union{Int, Missing}) == "b"
 
 # issue #15280

--- a/test/specificity.jl
+++ b/test/specificity.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 function args_morespecific(a, b)
-    sp = (ccall(:jl_type_morespecific, Cint, (Any,Any), a, b) != 0)
+    sp = Base.morespecific(a, b)
     if sp  # make sure morespecific(a,b) implies !morespecific(b,a)
-        @test ccall(:jl_type_morespecific, Cint, (Any,Any), b, a) == 0
+        @test !Base.morespecific(b, a)
     end
     return sp
 end


### PR DESCRIPTION
We already allowed method shadowing for an inexact signature and implicit method deletion by exact signatures, so it was fairly arbitrary to implement it as a deletion for a replacement by an exact signature rather than use the morespecific definition for this.

This change should be useful to Mocking libraries, such as Pluto, which previously had a buggier version of this which tried to re-activate or re-define the old methods.

There is a bit of code cleanup in here, either of unused features, or of aspects that were broken, or of world_valid computations that were not actually impacting the final result (e.g. when there is a more specific result matches, it does not need to limit the result valid world range because of a less specific result that does not get returned).