### PR TITLE
fix `nextpow`, `prevpow` for types without `typemax`

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -488,7 +488,8 @@ function nextpow(a::Real, x::Real)
     n = ceil(Integer,log(a, x))
     # round-off error of log can go either direction, so need some checks
     p = a^(n-1)
-    x > typemax(p) && throw(DomainError(x,"argument is beyond the range of type of the base"))
+    hastypemax(typeof(p)) && x > typemax(p) &&
+        throw(DomainError(x,"argument is beyond the range of type of the base"))
     p >= x && return p
     wp = a^n
     wp > p || throw(OverflowError("result is beyond the range of type of the base"))
@@ -529,9 +530,10 @@ function prevpow(a::T, x::Real) where T <: Real
     n = floor(Integer,log(a, x))
     # round-off error of log can go either direction, so need some checks
     p = a^n
-    x > typemax(p) && throw(DomainError(x,"argument is beyond the range of type of the base"))
+    hastypemax(typeof(p)) && x > typemax(p) &&
+        throw(DomainError(x,"argument is beyond the range of type of the base"))
     if a isa Integer
-        wp, overflow = mul_with_overflow(a, p)
+        wp, overflow = mul_with_overflow(promote(a, p)...)
         wp <= x && !overflow && return wp
     else
         wp = a^(n+1)

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -278,6 +278,18 @@ end
 end
 
 @testset "nextpow/prevpow" begin
+    @testset "small BigInt: $f $R" for f ∈ (prevpow, nextpow),
+                                       P ∈ (Int8, Int16, Int32, Int64, Int128),
+                                       R ∈ (Int8, Int16, Int32, Int64, Int128),
+                                       p ∈ 1:64,
+                                       r ∈ 2:5
+        q = P(p)
+        n = R(r)
+        for a ∈ (n, unsigned(n)), b ∈ (q, unsigned(q))
+            @test f(a, b) == f(a, big(b))
+        end
+    end
+
     @test nextpow(2, 3) == 4
     @test nextpow(2, 4) == 4
     @test nextpow(2, 7) == 8
@@ -291,7 +303,14 @@ end
     @test prevpow(10, 101.0) === 100
     @test prevpow(10.0, 101) === 100.0
     @test_throws DomainError prevpow(0, 3)
-    @test_throws DomainError prevpow(0, 3)
+    @test_throws DomainError prevpow(3, 0)
+
+    # "argument is beyond the range of type of the base"
+    @test_throws DomainError prevpow(Int8(3), 243)
+    @test_throws DomainError nextpow(Int8(3), 243)
+
+    # "result is beyond the range of type of the base"
+    @test_throws OverflowError nextpow(Int8(3), 82)
 end
 
 @testset "ndigits/ndigits0z" begin


### PR DESCRIPTION
Without this change `prevpow` and `nextpow` fail for, e.g., `BigInt`; incorrectly throwing a `MethodError`. For example, calls like `prevpow(3, big"10")` or `nextpow(3, big"10")` fail.

The issue is that the code incorrectly assumes the existence of a `typemax` method.

Another issue was a missing `promote` for the arguments of a `Base.Checked.mul_with_overflow` call.

Furthermore, the test coverage for `prevpow` and `nextpow` is improved.